### PR TITLE
fix getPositionFromLatLongHeight to not convert degress to radians

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -856,7 +856,7 @@ function collectAttributions(tiles) {
     .sort((a, b) => b[1] - a[1])
     .map(([attr,]) => attr);
 
-  const attributionString = sortedAttributions.join(', ');
+  const attributionString = sortedAttributions.join('; ');
   return attributionString;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -523,8 +523,8 @@ class Loader3DTiles {
         },
         getPositionFromLatLongHeight: (coord) => {
           const cartesianPosition = tileset.ellipsoid.cartographicToCartesian([
-            toRadians(coord.long),
-            toRadians(coord.lat),
+            coord.long,
+            coord.lat,
             coord.height
           ]);
           return new Vector3(...cartesianPosition).applyMatrix4(threeMat);

--- a/src/index.ts
+++ b/src/index.ts
@@ -459,7 +459,7 @@ class Loader3DTiles {
       return frameState;
     }
 
-    function setGeoTransformation(root, transformationMatrix) {
+    function setGeoTransformation(transformationMatrix) {
       const position = new Vector3();
       const quaternion = new Quaternion();
       const scale = new Vector3();
@@ -475,6 +475,13 @@ class Loader3DTiles {
       // Update the root object's matrix to reflect the changes
       root.updateMatrix();
       root.updateMatrixWorld(true);
+
+      lastRootTransform.copy(root.matrixWorld);
+      threeMat.copy(lastRootTransform);
+
+      tileset.modelMatrix = new MathGLMatrix4(transformationMatrix.toArray());
+      rootTransformInverse.copy(lastRootTransform).invert();
+      
     }
 
     return {
@@ -561,10 +568,8 @@ class Loader3DTiles {
           );
 
           const geoTransform = new Matrix4().copy(ellipsoidTransform).multiply(alignRotation).invert()
-          
-          tileset.modelMatrix = new MathGLMatrix4(geoTransform.toArray());
 
-          setGeoTransformation(root, geoTransform);
+          setGeoTransformation(geoTransform);
         },
         
         getCameraFrustum: (camera: Camera) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,8 @@ import {
   PerspectiveCamera,
   WebGLRenderer,
   Texture,
-  Euler
+  Euler,
+  Quaternion
 } from 'three';
 
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
@@ -458,6 +459,24 @@ class Loader3DTiles {
       return frameState;
     }
 
+    function setGeoTransformation(root, transformationMatrix) {
+      const position = new Vector3();
+      const quaternion = new Quaternion();
+      const scale = new Vector3();
+
+      // Decompose the matrix into position, quaternion, and scale
+      transformationMatrix.decompose(position, quaternion, scale);
+
+      // Apply the decomposed values to the root object
+      root.position.copy(position);
+      root.quaternion.copy(quaternion);
+      root.scale.copy(scale);
+
+      // Update the root object's matrix to reflect the changes
+      root.updateMatrix();
+      root.updateMatrixWorld(true);
+    }
+
     return {
       model: root,
       runtime: {
@@ -545,9 +564,9 @@ class Loader3DTiles {
           
           tileset.modelMatrix = new MathGLMatrix4(geoTransform.toArray());
 
-          root.applyMatrix4(geoTransform);
-          root.updateMatrixWorld(true);
+          setGeoTransformation(root, geoTransform);
         },
+        
         getCameraFrustum: (camera: Camera) => {
           const frustum = Util.getCameraFrustum(camera);
           const meshes = frustum.planes

--- a/src/index.ts
+++ b/src/index.ts
@@ -837,6 +837,8 @@ function cameraChanged(camera:Camera, lastCameraTransform:Matrix4, lastCameraAsp
 }
 
 function collectAttributions(tiles) {
+  // attribution guidelines: https://developers.google.com/maps/documentation/tile/create-renderer#display-attributions
+  
   const copyrightCounts = new Map(); // Use a Map to keep track of counts
 
   tiles.forEach(tile => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -569,7 +569,7 @@ class Loader3DTiles {
             if (!lastRootTransform.equals(root.matrixWorld)) {
               timer = 0;
               lastRootTransform.copy(root.matrixWorld);
-              if (options.geoTransform == GeoTransform.Reset || options.geoTransform == GeoTransform.Mercator) {
+              if (options.geoTransform == GeoTransform.WGS84Cartesian || options.geoTransform == GeoTransform.Reset || options.geoTransform == GeoTransform.Mercator) {
                 updateResetTransform();
               }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -131,6 +131,8 @@ interface Runtime {
   getStats(): Stats;
   /** Get the tile bounding boxes group when `debug: true` is set. */
   getTileBoxes(): Object3D;
+  /** Get the tileset's attribution text. */
+  getDataAttributions(): string;
   /** Show or hide the tile bounding boxes. */
   showTiles(boolean): void;
   /** Enable or disable wireframe mode. */


### PR DESCRIPTION
The function tileset.ellipsoid.cartographicToCartesian(...) takes latitude and longitude in degrees, so there should not be a conversion to radians. This function is also called (correctly) in orientToGeocoord(...) with latitude and longitude in degrees.