### PR TITLE
fixed r3f example

### DIFF
--- a/examples/r3f/src/index.tsx
+++ b/examples/r3f/src/index.tsx
@@ -1,37 +1,42 @@
-import * as ReactDOM from 'react-dom/client'
-import { useState, useRef, Suspense } from 'react'
-import { Canvas } from '@react-three/fiber'
-import { PerspectiveCamera, OrbitControls } from '@react-three/drei'
+import * as ReactDOM from 'react-dom/client';
+import { useState, useRef, Suspense } from 'react';
+import { Canvas } from '@react-three/fiber';
+import { PerspectiveCamera, OrbitControls } from '@react-three/drei';
 import { ErrorBoundary } from 'react-error-boundary';
-import { Matrix4, Euler } from 'three'
+import { Matrix4, Euler } from 'three';
 
-import { Loader3DTilesR3FAsset } from './loader-3dtiles-r3f'
+import { Loader3DTilesR3FAsset } from './loader-3dtiles-r3f';
 
 function App() {
   const camera = useRef(null);
 
   return (
     <div id="canvas-container">
-      <Canvas style={{ background: '#272730'}}>
+      <Canvas style={{ background: '#272730' }}>
         <PerspectiveCamera ref={camera}>
-          <ErrorBoundary fallbackRender={() => (
-            <mesh>
-              <sphereGeometry />
-              <meshBasicMaterial color="red" />
-            </mesh>
-          )}>
-            <Suspense fallback={
+          <ErrorBoundary
+            fallbackRender={() => (
               <mesh>
                 <sphereGeometry />
-                <meshBasicMaterial color="yellow" />
+                <meshBasicMaterial color="red" />
               </mesh>
-            }>
+            )}
+          >
+            <Suspense
+              fallback={
+                <mesh>
+                  <sphereGeometry />
+                  <meshBasicMaterial color="yellow" />
+                </mesh>
+              }
+            >
               <Loader3DTilesR3FAsset
-                 dracoDecoderPath={"https://unpkg.com/three@0.160.0/examples/jsm/libs/draco"}
-                 basisTranscoderPath={"https://unpkg.com/three@0.160.0/examples/jsm/libs/basis"}
-                 rotation={new Euler(-Math.PI / 2, 0, 0)}
-                 url="https://int.nyt.com/data/3dscenes/ONA360/TILESET/0731_FREEMAN_ALLEY_10M_A_36x8K__10K-PN_50P_DB/tileset_tileset.json"
+                dracoDecoderPath={'https://unpkg.com/three@0.160.0/examples/jsm/libs/draco'}
+                basisTranscoderPath={'https://unpkg.com/three@0.160.0/examples/jsm/libs/basis'}
+                rotation={new Euler(-Math.PI / 2, 0, 0)}
+                url="https://int.nyt.com/data/3dscenes/ONA360/TILESET/0731_FREEMAN_ALLEY_10M_A_36x8K__10K-PN_50P_DB/tileset_tileset.json"
                 maximumScreenSpaceError={48}
+                resetTransform={true}
               />
             </Suspense>
           </ErrorBoundary>
@@ -39,7 +44,7 @@ function App() {
         <OrbitControls camera={camera.current} />
       </Canvas>
     </div>
-  )
+  );
 }
 
 const root = ReactDOM.createRoot(document.getElementById('root'));

--- a/examples/r3f/src/loader-3dtiles-r3f.tsx
+++ b/examples/r3f/src/loader-3dtiles-r3f.tsx
@@ -16,7 +16,6 @@ class Loader3DTilesBridge extends Loader {
          onLoad(result);
       }
       catch(e) {
-        console.log("Error loading 3d tiles!", e);
         onError(e);
       }
     }
@@ -44,7 +43,7 @@ function Loader3DTilesR3FAsset(props) {
   })
 
   useFrame(({ size, camera }, dt) => {
-    runtime.update(dt, size.height, camera);
+    runtime.update(dt, camera);
   });
 
   return (


### PR DESCRIPTION
Hello! Thanks for this great 3d tiles viewer. I could make it work in my r3f app after two small changes:
- runtime.update() signature changed but old one was still used, removed viewport height param from function call in useFrame()
- resetTransform props of loader manager set to true so the tileset position is in the middle of the scene in front of the camera (default [0,0,0])
